### PR TITLE
missing quote around LIKE clause arg

### DIFF
--- a/pkg/cfg/cfgmgr.go
+++ b/pkg/cfg/cfgmgr.go
@@ -170,7 +170,7 @@ func (c *CfgMgr) CreateDB(serviceName, userName string) (updateConsul bool, err 
     if err != nil {
         return false, err
     }
-    _, err = dbObject.Exec(fmt.Sprintf("SHOW DATABASES LIKE %s", serviceName))
+    _, err = dbObject.Exec(fmt.Sprintf("SHOW DATABASES LIKE '%s'", serviceName))
     if err == nil {
         zap.L().Info(fmt.Sprintf("Database %s already exists", serviceName))
         return false, nil


### PR DESCRIPTION
Error snippet with the existing code
```
bash-5.0# go run test.go 
go: finding github.com/go-sql-driver/mysql v1.6.0

go: downloading github.com/go-sql-driver/mysql v1.6.0
go: extracting github.com/go-sql-driver/mysql v1.6.0
2022/03/15 17:58:06 Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'hagrid' at line 1
```
after fix:
bash-5.0# go run test.go 
Database hagrid already existsbash-5.0# 
bash-5.0# 

