### PR TITLE
[AIR-1365] Mysql 8.0 compatibility

### DIFF
--- a/pkg/cfg/cfgmgr.go
+++ b/pkg/cfg/cfgmgr.go
@@ -3,17 +3,18 @@
 package cfg
 
 import (
-    "errors"
-    "fmt"
-    rand "math/rand"
-    "reflect"
-    "sort"
-    "time"
+	"errors"
+	"fmt"
+	rand "math/rand"
+	"reflect"
+	"sort"
+	"time"
 
-    consul "github.com/hashicorp/consul/api"
-    "database/sql"
-    _ "github.com/go-sql-driver/mysql"
-    "go.uber.org/zap"
+	"database/sql"
+
+	_ "github.com/go-sql-driver/mysql"
+	consul "github.com/hashicorp/consul/api"
+	"go.uber.org/zap"
 )
 
 // ErrorNotFound signifies absence of SSO configuration
@@ -101,7 +102,7 @@ func (c *CfgMgr) GetKeystonePassword(serviceName string) (string, error) {
 	return password, nil
 }
 
-//  AddKeystoneUser
+// AddKeystoneUser
 func (c *CfgMgr) AddKeystoneUser(serviceName string) error {
 	zap.L().Debug("Creating keystone user for serviceName ", zap.String("serviceName", serviceName))
 
@@ -151,146 +152,153 @@ func (c *CfgMgr) getValue(key string) (string, error) {
 	return "", fmt.Errorf("Key value for key %s not found", key)
 }
 
-func (c * CfgMgr) GetRandomPassword() string {
-    rand.Seed(time.Now().UnixNano())
-    digits := "0123456789"
-    lowerChars := "abcdefghijklmnopqrstuvwxyz"
-    upperChars := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    allChars := lowerChars + upperChars + digits
-    const max = 16
-    out := make([]byte, max)
-    for i := 0; i < max; i++ {
-        out[i] = allChars[rand.Intn(len(allChars))]
-    }
-    return string(out)
+func (c *CfgMgr) GetRandomPassword() string {
+	rand.Seed(time.Now().UnixNano())
+	digits := "0123456789"
+	lowerChars := "abcdefghijklmnopqrstuvwxyz"
+	upperChars := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	allChars := lowerChars + upperChars + digits
+	const max = 16
+	out := make([]byte, max)
+	for i := 0; i < max; i++ {
+		out[i] = allChars[rand.Intn(len(allChars))]
+	}
+	return string(out)
 }
 
 func (c *CfgMgr) CreateDB(serviceName, userName string) (updateConsul bool, err error) {
-    dbObject, err := c.getDbObject()
-    if err != nil {
-        return false, err
-    }
+	dbObject, err := c.getDbObject()
+	if err != nil {
+		return false, err
+	}
 
-    zap.L().Debug("Creating DB for serviceName ", zap.String("serviceName", serviceName))
-    _, err = dbObject.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", serviceName))
-    if err != nil {
-        zap.L().Error("Error while creating database", zap.Error(err))
-        return false, err
-    }
-    zap.L().Info(fmt.Sprintf("Created DB '%s' successfully", serviceName))
-    return true, nil
+	zap.L().Debug("Creating DB for serviceName ", zap.String("serviceName", serviceName))
+	_, err = dbObject.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", serviceName))
+	if err != nil {
+		zap.L().Error("Error while creating database", zap.Error(err))
+		return false, err
+	}
+	zap.L().Info(fmt.Sprintf("Created DB '%s' successfully", serviceName))
+	return true, nil
 }
 
 func (c *CfgMgr) CreateGrants(dbName, userName, dbPassword string) (bool, error) {
-    dbObject, err := c.getDbObject()
-    if err != nil {
-        return false, err
-    }
-    rows, err := dbObject.Query("SELECT @@hostname")
-    if err != nil {
-        zap.L().Error("Error while getting hostname", zap.Error(err))
-        return false, err
-    }
-    defer rows.Close()
-    var hostname string
-    count := 0
-    for rows.Next() {
-        _ = rows.Scan(&hostname)
-    }
-    hosts := []string{"localhost", "%", hostname}
-    for _, hostName := range hosts {
-        before_grants := c.getGrants(userName, hostName, dbObject)
-        query := fmt.Sprintf("GRANT ALL PRIVILEGES ON %s.* TO '%s'@'%s' IDENTIFIED BY '%s'",
-                             dbName, userName, hostName, dbPassword)
-        _, _ = dbObject.Exec(query)
-        after_grants := c.getGrants(userName, hostName, dbObject)
-        if (reflect.DeepEqual(before_grants, after_grants)) {
-            count += 1
-        }
-    }
-    if count == len(hosts) {
-        return false, nil
-    } else {
-        return true, nil
-    }
+	dbObject, err := c.getDbObject()
+	if err != nil {
+		return false, err
+	}
+	rows, err := dbObject.Query("SELECT @@hostname")
+	if err != nil {
+		zap.L().Error("Error while getting hostname", zap.Error(err))
+		return false, err
+	}
+	defer rows.Close()
+	var hostname string
+	count := 0
+	for rows.Next() {
+		_ = rows.Scan(&hostname)
+	}
+	hosts := []string{"localhost", "%", hostname}
+	for _, hostName := range hosts {
+		before_grants := c.getGrants(userName, hostName, dbObject)
+
+		createUserQuery := "CREATE USER IF NOT EXISTS ?@? IDENTIFIED BY ?"
+		_, err = dbObject.Exec(createUserQuery, userName, hostName, dbPassword)
+
+		grantQuery := fmt.Sprintf("GRANT ALL PRIVILEGES ON `%s`.* TO ?@?", dbName)
+		_, err = dbObject.Exec(grantQuery, userName, hostName)
+
+		// query := fmt.Sprintf("GRANT ALL PRIVILEGES ON %s.* TO '%s'@'%s' IDENTIFIED BY '%s'",
+		//                      dbName, userName, hostName, dbPassword)
+		// _, _ = dbObject.Exec(query)
+		after_grants := c.getGrants(userName, hostName, dbObject)
+		if reflect.DeepEqual(before_grants, after_grants) {
+			count += 1
+		}
+	}
+	if count == len(hosts) {
+		return false, nil
+	} else {
+		return true, nil
+	}
 }
 
 func (c *CfgMgr) getDbDetails() (string, string, string, string, error) {
-    dbserver, err := c.getValue(fmt.Sprintf("%s/keystone/dbserver_key", c.CustomerKeyPrefix))
-    if err != nil {
-        zap.L().Error("Cannot get dbserver_key from consul store", zap.Error(err))
-        return "", "", "", "", err
-    }
-    host, err := c.getValue(fmt.Sprintf("%s/host", dbserver))
-    if err != nil {
-        zap.L().Error("Cannot get host key from consul store", zap.Error(err))
-        return "", "", "", "", err
-    }
-    port, err := c.getValue(fmt.Sprintf("%s/port", dbserver))
-    if err != nil {
-        zap.L().Error("Cannot get port key from consul store", zap.Error(err))
-        return "", "", "", "", err
-    }
-    adminUser, err := c.getValue(fmt.Sprintf("%s/admin_user", dbserver))
-    if err != nil {
-        zap.L().Error("Cannot get admin_user key from consul store", zap.Error(err))
-        return "", "", "", "", err
-    }
-    adminPass, err := c.getValue(fmt.Sprintf("%s/admin_pass", dbserver))
-    if err != nil {
-        zap.L().Error("Cannot get admin_pass key from consul store", zap.Error(err))
-        return "", "", "", "", err
-    }
-    return host, port, adminUser, adminPass, nil
+	dbserver, err := c.getValue(fmt.Sprintf("%s/keystone/dbserver_key", c.CustomerKeyPrefix))
+	if err != nil {
+		zap.L().Error("Cannot get dbserver_key from consul store", zap.Error(err))
+		return "", "", "", "", err
+	}
+	host, err := c.getValue(fmt.Sprintf("%s/host", dbserver))
+	if err != nil {
+		zap.L().Error("Cannot get host key from consul store", zap.Error(err))
+		return "", "", "", "", err
+	}
+	port, err := c.getValue(fmt.Sprintf("%s/port", dbserver))
+	if err != nil {
+		zap.L().Error("Cannot get port key from consul store", zap.Error(err))
+		return "", "", "", "", err
+	}
+	adminUser, err := c.getValue(fmt.Sprintf("%s/admin_user", dbserver))
+	if err != nil {
+		zap.L().Error("Cannot get admin_user key from consul store", zap.Error(err))
+		return "", "", "", "", err
+	}
+	adminPass, err := c.getValue(fmt.Sprintf("%s/admin_pass", dbserver))
+	if err != nil {
+		zap.L().Error("Cannot get admin_pass key from consul store", zap.Error(err))
+		return "", "", "", "", err
+	}
+	return host, port, adminUser, adminPass, nil
 }
 
 func (c *CfgMgr) getDbObject() (*sql.DB, error) {
-    host, port, adminUser, adminPass, err := c.getDbDetails()
-    if err != nil {
-        return nil, err
-    }
-    dbObject, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%s)/", adminUser, adminPass, host, port))
-    if err != nil {
-        zap.L().Error("Can't connect to MySQL", zap.Error(err))
-        return nil, err
-    }
-    return dbObject, nil
+	host, port, adminUser, adminPass, err := c.getDbDetails()
+	if err != nil {
+		return nil, err
+	}
+	dbObject, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%s)/", adminUser, adminPass, host, port))
+	if err != nil {
+		zap.L().Error("Can't connect to MySQL", zap.Error(err))
+		return nil, err
+	}
+	return dbObject, nil
 }
 
 func (c *CfgMgr) UpdateConsul(serviceName, userName, dbPassword string) error {
-    host, port, _, _, err := c.getDbDetails()
-    if err != nil {
-        return err
-    }
-    dbPrefix := fmt.Sprintf("%s/%s/db", c.CustomerKeyPrefix, serviceName)
-    ops := consul.KVTxnOps{
-        &consul.KVTxnOp{Verb: consul.KVSet, Key: fmt.Sprintf("%s/name", dbPrefix), Value: []byte(serviceName)},
-        &consul.KVTxnOp{Verb: consul.KVSet, Key: fmt.Sprintf("%s/password", dbPrefix), Value: []byte(dbPassword)},
-        &consul.KVTxnOp{Verb: consul.KVSet, Key: fmt.Sprintf("%s/user", dbPrefix), Value: []byte(userName)},
-        &consul.KVTxnOp{Verb: consul.KVSet, Key: fmt.Sprintf("%s/host", dbPrefix), Value: []byte(host)},
-        &consul.KVTxnOp{Verb: consul.KVSet, Key: fmt.Sprintf("%s/port", dbPrefix), Value: []byte(port)},
-    }
-    _, _, _, err = c.ConsulKV.Txn(ops, nil)
-    if err != nil {
-        zap.L().Error("Can't write db config to Consul", zap.Error(err))
-        return err
-    }
-    return nil
+	host, port, _, _, err := c.getDbDetails()
+	if err != nil {
+		return err
+	}
+	dbPrefix := fmt.Sprintf("%s/%s/db", c.CustomerKeyPrefix, serviceName)
+	ops := consul.KVTxnOps{
+		&consul.KVTxnOp{Verb: consul.KVSet, Key: fmt.Sprintf("%s/name", dbPrefix), Value: []byte(serviceName)},
+		&consul.KVTxnOp{Verb: consul.KVSet, Key: fmt.Sprintf("%s/password", dbPrefix), Value: []byte(dbPassword)},
+		&consul.KVTxnOp{Verb: consul.KVSet, Key: fmt.Sprintf("%s/user", dbPrefix), Value: []byte(userName)},
+		&consul.KVTxnOp{Verb: consul.KVSet, Key: fmt.Sprintf("%s/host", dbPrefix), Value: []byte(host)},
+		&consul.KVTxnOp{Verb: consul.KVSet, Key: fmt.Sprintf("%s/port", dbPrefix), Value: []byte(port)},
+	}
+	_, _, _, err = c.ConsulKV.Txn(ops, nil)
+	if err != nil {
+		zap.L().Error("Can't write db config to Consul", zap.Error(err))
+		return err
+	}
+	return nil
 }
 
 func (c *CfgMgr) getGrants(userName, host string, dbObject *sql.DB) []string {
-    var grants []string
-    var field string
-    rows, err := dbObject.Query(fmt.Sprintf("SHOW GRANTS FOR %s@%s", userName, host))
-    if err != nil {
-        zap.L().Error("Error while getting grants for user")
-        return grants
-    }
-    defer rows.Close()
-    for rows.Next() {
-        _ = rows.Scan(&field)
-    }
-    grants = append(grants, field)
-    sort.Strings(grants)
-    return grants
+	var grants []string
+	var field string
+	rows, err := dbObject.Query(fmt.Sprintf("SHOW GRANTS FOR %s@%s", userName, host))
+	if err != nil {
+		zap.L().Error("Error while getting grants for user")
+		return grants
+	}
+	defer rows.Close()
+	for rows.Next() {
+		_ = rows.Scan(&field)
+	}
+	grants = append(grants, field)
+	sort.Strings(grants)
+	return grants
 }

--- a/pkg/cfg/cfgmgr.go
+++ b/pkg/cfg/cfgmgr.go
@@ -209,7 +209,7 @@ func (c *CfgMgr) CreateGrants(dbName, userName, dbPassword string) (bool, error)
 			fmt.Println("Error creating user:", err)
 		}
 
-		grantPrivilegesQuery := "GRANT ALL PRIVILEGES ON *.* TO '" + userName + "'@'" + hostName + "'"
+		grantPrivilegesQuery := "GRANT ALL PRIVILEGES ON `" + dbName + "`.* TO '" + userName + "'@'" + hostName + "'"
 		_, err = dbObject.Exec(grantPrivilegesQuery)
 
 		if err != nil {

--- a/pkg/cfg/cfgmgr.go
+++ b/pkg/cfg/cfgmgr.go
@@ -210,6 +210,7 @@ func (c *CfgMgr) CreateGrants(dbName, userName, dbPassword string) (bool, error)
 		}
 
 		grantPrivilegesQuery := "GRANT ALL PRIVILEGES ON `" + dbName + "`.* TO '" + userName + "'@'" + hostName + "'"
+		fmt.Println("Grating privileges to %s@%s on DB %s", userName, hostName, dbName)
 		_, err = dbObject.Exec(grantPrivilegesQuery)
 
 		if err != nil {

--- a/pkg/cfg/cfgmgr.go
+++ b/pkg/cfg/cfgmgr.go
@@ -203,6 +203,7 @@ func (c *CfgMgr) CreateGrants(dbName, userName, dbPassword string) (bool, error)
 		before_grants := c.getGrants(userName, hostName, dbObject)
 
 		createUserQuery := "CREATE USER IF NOT EXISTS '" + userName + "'@'" + hostName + "' IDENTIFIED BY '" + dbPassword + "'"
+		fmt.Println("Creating user %s@%s using password %s", userName, hostName, dbPassword)
 		_, err = dbObject.Exec(createUserQuery)
 		if err != nil {
 			// Handle the error

--- a/pkg/cfg/cfgmgr.go
+++ b/pkg/cfg/cfgmgr.go
@@ -202,16 +202,15 @@ func (c *CfgMgr) CreateGrants(dbName, userName, dbPassword string) (bool, error)
 	for _, hostName := range hosts {
 		before_grants := c.getGrants(userName, hostName, dbObject)
 
-		createUserQuery := "CREATE USER IF NOT EXISTS ?@? IDENTIFIED BY ?"
-		_, err = dbObject.Exec(createUserQuery, userName, hostName, dbPassword)
-		fmt.Println(userName)
+		createUserQuery := "CREATE USER IF NOT EXISTS '" + userName + "'@'" + hostName + "' IDENTIFIED BY '" + dbPassword + "'"
+		_, err = dbObject.Exec(createUserQuery)
 		if err != nil {
 			// Handle the error
 			fmt.Println("Error creating user:", err)
 		}
 
-		grantQuery := fmt.Sprintf("GRANT ALL PRIVILEGES ON `%s`.* TO ?@?", dbName)
-		_, err = dbObject.Exec(grantQuery, userName, hostName)
+		grantPrivilegesQuery := "GRANT ALL PRIVILEGES ON *.* TO '" + userName + "'@'" + hostName + "'"
+		_, err = dbObject.Exec(grantPrivilegesQuery)
 
 		if err != nil {
 			// Handle the error

--- a/pkg/cfg/cfgmgr.go
+++ b/pkg/cfg/cfgmgr.go
@@ -298,7 +298,7 @@ func (c *CfgMgr) UpdateConsul(serviceName, userName, dbPassword string) error {
 func (c *CfgMgr) getGrants(userName, host string, dbObject *sql.DB) []string {
 	var grants []string
 	var field string
-	rows, err := dbObject.Query(fmt.Sprintf("SHOW GRANTS FOR %s@%s", userName, host))
+	rows, err := dbObject.Query("SHOW GRANTS FOR '" + userName + "'@'" + host + "'")
 	if err != nil {
 		zap.L().Error("Error while getting grants for user")
 		return grants

--- a/pkg/cfg/cfgmgr.go
+++ b/pkg/cfg/cfgmgr.go
@@ -204,9 +204,19 @@ func (c *CfgMgr) CreateGrants(dbName, userName, dbPassword string) (bool, error)
 
 		createUserQuery := "CREATE USER IF NOT EXISTS ?@? IDENTIFIED BY ?"
 		_, err = dbObject.Exec(createUserQuery, userName, hostName, dbPassword)
+		fmt.Println(userName)
+		if err != nil {
+			// Handle the error
+			fmt.Println("Error creating user:", err)
+		}
 
 		grantQuery := fmt.Sprintf("GRANT ALL PRIVILEGES ON `%s`.* TO ?@?", dbName)
 		_, err = dbObject.Exec(grantQuery, userName, hostName)
+
+		if err != nil {
+			// Handle the error
+			fmt.Println("Error granting privileges:", err)
+		}
 
 		// query := fmt.Sprintf("GRANT ALL PRIVILEGES ON %s.* TO '%s'@'%s' IDENTIFIED BY '%s'",
 		//                      dbName, userName, hostName, dbPassword)

--- a/pkg/cfg/cfgmgr.go
+++ b/pkg/cfg/cfgmgr.go
@@ -298,11 +298,11 @@ func (c *CfgMgr) UpdateConsul(serviceName, userName, dbPassword string) error {
 func (c *CfgMgr) getGrants(userName, host string, dbObject *sql.DB) []string {
 	var grants []string
 	var field string
-	rows, err := dbObject.Query("SHOW GRANTS FOR '" + userName + "'@'" + host + "'")
-	if err != nil {
-		zap.L().Error("Error while getting grants for user")
-		return grants
-	}
+	rows, err := dbObject.Query(fmt.Sprintf("SHOW GRANTS FOR '%s'@'%s'", userName, host))
+    if err != nil {
+        zap.L().Error("Error while getting grants for user", zap.Error(err))
+        return grants
+    }
 	defer rows.Close()
 	for rows.Next() {
 		_ = rows.Scan(&field)

--- a/pkg/cfg/cfgmgr.go
+++ b/pkg/cfg/cfgmgr.go
@@ -203,13 +203,6 @@ func (c *CfgMgr) CreateGrants(dbName, userName, dbPassword string) (bool, error)
 	for _, hostName := range hosts {
 		before_grants := c.getGrants(userName, hostName, dbObject)
 
-		// createUserQuery := "CREATE USER IF NOT EXISTS '" + userName + "'@'" + hostName + "' IDENTIFIED BY '" + dbPassword + "'"
-		// fmt.Println("Creating user %s@%s using password %s", userName, hostName, dbPassword)
-		// _, err = dbObject.Exec(createUserQuery)
-		// if err != nil {
-		// 	// Handle the error
-		// 	fmt.Println("Error creating user:", err)
-		// }
 		var exists bool
 		query := "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = ? AND host = ?)"
 		err := dbObject.QueryRow(query, userName, hostName).Scan(&exists)
@@ -224,7 +217,6 @@ func (c *CfgMgr) CreateGrants(dbName, userName, dbPassword string) (bool, error)
 			if err != nil {
 				log.Fatalf("Error updating user password: %v", err)
 			}
-			fmt.Printf("Password for user '%s'@'%s' updated successfully.\n", userName, hostName)
 		} else {
 			// Create the user if it does not exist
 			createUserQuery := "CREATE USER '" + userName + "'@'" + hostName + "' IDENTIFIED BY '" + dbPassword + "'"
@@ -236,7 +228,6 @@ func (c *CfgMgr) CreateGrants(dbName, userName, dbPassword string) (bool, error)
 		}
 
 		grantPrivilegesQuery := "GRANT ALL PRIVILEGES ON `" + dbName + "`.* TO '" + userName + "'@'" + hostName + "'"
-		fmt.Println("Grating privileges to %s@%s on DB %s", userName, hostName, dbName)
 		_, err = dbObject.Exec(grantPrivilegesQuery)
 
 		if err != nil {


### PR DESCRIPTION
This PR solves [AIR-1365](https://platform9.atlassian.net/browse/AIR-1365)

We had to divide the grant privilege query into two parts because MySql 8.0 doesn't create a user for granting privileges if it doesn't exist unlike in MySql 5.7.

Testing:
The hagrid pod is up and running after upgrading the DU.
```
➜  Downloads k get po
NAME                                           READY   STATUS    RESTARTS        AGE
alertmanager-67b9995df7-2cdb8                  1/1     Running   0               16m
blackbox-exporter-5c47b5549b-nmg7q             2/2     Running   0               16m
capa-controller-manager-7ff7649986-d4d72       1/1     Running   0               21m
capi-controller-manager-6d9b57f8c7-66q8m       1/1     Running   0               21m
cert-manager-86c88547d7-hhfjl                  1/1     Running   5 (20m ago)     130m
cert-manager-cainjector-7469d5bb67-qrgb6       1/1     Running   7 (20m ago)     130m
cert-manager-webhook-575cc8c995-mdb8q          1/1     Running   0               130m
clarity-d4b87d955-lncdg                        1/1     Running   0               16m
forwarder-cdbcc5686-hkhtf                      7/7     Running   0               16m
hagrid-7d6bcd5d59-dwq62                        3/3     Running   7 (10m ago)     16m
ingress-nginx-controller-79b85bc8c4-m6pfj      2/2     Running   0               36m
keystone-66ffc7d845-rtbvh                      2/2     Running   0               34m
memcached-5546f6f55-j9cwd                      1/1     Running   0               119m
mysql-5749d7fbc9-cpxjm                         3/3     Running   0               16m
mysqld-exporter-5476fc8bd6-v8s7p               2/2     Running   0               16m
pf9-capi-controller-manager-5c65d4974b-5xlpc   1/1     Running   2 (6m41s ago)   21m
pf9-capi-server-944666fbc-gqntd                2/2     Running   1 (35m ago)     36m
pf9-dex-5756f968bf-xk756                       1/1     Running   7 (12m ago)     22m
pf9-nginx-845767bd7c-4s4z8                     2/2     Running   0               16m
pf9-notifications-75cfd54cf5-5gzv9             4/4     Running   0               16m
pf9-vault-6f57ccf749-n6gsc                     2/2     Running   0               12m
preference-store-58996bc56b-8vbjr              1/1     Running   7 (10m ago)     16m
prometheus-8684c89bcc-m7z64                    13/13   Running   0               16m
qbert-695795c479-nqpmw                         13/13   Running   1 (12m ago)     28m
rabbitmq-7959b8b94d-6q2jv                      2/2     Running   0               16m
remote-write-proxy-847c9cfddf-lhlg7            1/1     Running   0               36m
resmgr-6c86765f6f-bqpjj                        7/7     Running   0               36m
sentinel-cdc898b8c-cpxhr                       1/1     Running   0               36m
serenity-7d78c698b4-6cm66                      1/1     Running   0               36m
sidekickserver-67b5dbdfd5-gqpvs                2/2     Running   0               36m
sunpike-apiserver-6b8f6d4d7-hxv67              3/3     Running   11 (10m ago)    36m
sunpike-conductor-7db4764cc6-zw9v6             5/5     Running   9 (9m51s ago)   36m
sunpike-controller-manager-6bf6c8d856-4nhrg    2/2     Running   9 (6m20s ago)   36m
sunpike-kine-76b9868b6d-zcdgd                  2/2     Running   8 (15m ago)     36m
sunpike-kube-apiserver-747dbcf747-x56qn        4/4     Running   2 (36m ago)     36m
sunpike-kube-controllers-544945c6ff-brfhd      2/2     Running   7 (10m ago)     16m
vouch-keystone-6dc744446c-b8xbj                2/2     Running   0               16m
vouch-noauth-79bc995bf4-ngbgn                  3/3     Running   0               36m
```

[AIR-1365]: https://platform9.atlassian.net/browse/AIR-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ